### PR TITLE
Allow scanning images in repositories that are >1 level deep

### DIFF
--- a/internal/adapter/imagescanning/adapter.go
+++ b/internal/adapter/imagescanning/adapter.go
@@ -86,12 +86,6 @@ func (a Adapter) Scan(payload harbor.ScanRequest) (harbor.ScanResponse, error) {
 		return resp, err
 	}
 
-	splits := strings.Split(payload.Artifact.Repository, "/")
-	if len(splits) != 2 {
-		err := fmt.Errorf("Expected exactly 2 substrings but found %d", len(splits))
-		return resp, err
-	}
-
 	tag := payload.Artifact.Tag
 	if payload.Artifact.Tag == "" {
 		tag = payload.Artifact.Digest[7:]

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -32,11 +32,10 @@ func Queue() chan string {
 }
 
 func Publish(imageInfo ImageInfo) string {
-	locker.Lock()
-	defer locker.Unlock()
-
 	scanID := uuid.New().String()
+	locker.Lock()
 	imageInfoMap[scanID] = &imageInfo
+	locker.Unlock()
 	queue <- scanID
 	return scanID
 }


### PR DESCRIPTION
Fixes #16 

The check did not really make sense, not sure what is the historical reason for it. 

This was also observed and (hopefully) fixed:
* Due to unprotected concurrent access to a map, some panics were observed at times. Put a lock around  the map access to avoid this. 