### PR TITLE
Fix duplicate value in consumesMimeTypesMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ curl -s 127.0.0.1:8080/api/v1/metadata | jq
     {
       "consumes_mime_types": [
         "application/vnd.docker.distribution.manifest.v2+json",
-        "application/vnd.docker.distribution.manifest.v2+json"
+        "application/vnd.oci.image.manifest.v1+json"
       ],
       "produces_mime_types": [
         "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",

--- a/internal/adapter/imagescanning/adapter.go
+++ b/internal/adapter/imagescanning/adapter.go
@@ -34,7 +34,7 @@ var (
 	}
 	consumesMimeTypesMetadata = []string{
 		"application/vnd.docker.distribution.manifest.v2+json",
-		"application/vnd.docker.distribution.manifest.v2+json",
+		"application/vnd.oci.image.manifest.v1+json",
 	}
 	producesMimeTypesMetadata = []string{
 		"application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",

--- a/internal/adapter/imagescanning/adapter_test.go
+++ b/internal/adapter/imagescanning/adapter_test.go
@@ -8,7 +8,38 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	log "github.com/sirupsen/logrus"
+	"github.com/vmware/carbon-black-adapter-for-harbor/internal/model/harbor"
 )
+
+type fakeAdapter struct {
+	// scan []string
+}
+
+func NewFakeAdapter() fakeAdapter {
+	return fakeAdapter{
+		// scan: make([]string, 0),
+	}
+}
+
+func (a fakeAdapter) fakeGetMetadata() harbor.ScannerAdapterMetadata {
+	// this duplicates the Adapter.GetMetadata method
+	// but should use the existing data from Adapter
+	capability := harbor.ScannerCapability{
+		ConsumesMimeTypes: consumesMimeTypesMetadata,
+		ProducesMimeTypes: producesMimeTypesMetadata,
+	}
+
+	scannerMetadata := harbor.ScannerAdapterMetadata{
+		Properties:   propertiesMetadata,
+		Capabilities: []harbor.ScannerCapability{capability},
+		Scanner:      scannerInfo,
+	}
+
+	return scannerMetadata
+}
 
 func TestGetCredential(t *testing.T) {
 
@@ -28,4 +59,46 @@ func TestGetCredential(t *testing.T) {
 		t.Errorf("Pulled getting password")
 	}
 
+}
+
+func TestConsumesMimeTypesMetadata(t *testing.T) {
+	var expectConsumesMimeTypesMetadata = []string{
+		"application/vnd.docker.distribution.manifest.v2+json",
+		"application/vnd.oci.image.manifest.v1+json",
+	}
+
+	ad := NewFakeAdapter()
+	md := ad.fakeGetMetadata()
+
+	if !cmp.Equal(md.Capabilities[0].ConsumesMimeTypes, expectConsumesMimeTypesMetadata) {
+		t.Errorf("ConsumesMimeTypesMetadata did not match expected value %s", expectConsumesMimeTypesMetadata)
+	}
+}
+
+func TestProducesMimeTypesMetadata(t *testing.T) {
+	var expectProducesMimeTypesMetadata = []string{
+		"application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",
+		"application/vnd.security.vulnerability.report; version=1.1",
+	}
+
+	ad := NewFakeAdapter()
+	md := ad.fakeGetMetadata()
+
+	if !cmp.Equal(md.Capabilities[0].ProducesMimeTypes, expectProducesMimeTypesMetadata) {
+		t.Errorf("ProducesMimeTypesMetadata did not match expected value %s", expectProducesMimeTypesMetadata)
+	}
+}
+
+func TestPropertiesMetadata(t *testing.T) {
+	var expectPropertiesMetadata = map[string]string{
+		"harbor.scanner-adapter/scanner-type": "os-package-vulnerability",
+		"env.LOG_LEVEL":                       log.GetLevel().String(),
+	}
+
+	ad := NewFakeAdapter()
+	md := ad.fakeGetMetadata()
+
+	if !cmp.Equal(md.Properties, expectPropertiesMetadata) {
+		t.Errorf("PropertiesMetadata did not match expected value %s", expectPropertiesMetadata)
+	}
 }


### PR DESCRIPTION
This fixes a bug where the Adapter reports incorrect values in Capabilities.ConsumesMimeTypes, resulting in Harbor being unable to scan OCI images.  Related adapter metadata tests have also been added.  This resolves Carbon Black Case Number 00318433.

Tested locally in our container platform.

I have not updated any app or Chart version numbers under the assumption that the internal team would like to reserve that operation for themselves.