### PR TITLE
Release v2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster as basebuild
+FROM golang:1.22-bullseye as basebuild
 WORKDIR /harbor-adapter
 COPY / /harbor-adapter
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifndef release_version
 endif
 
 docker-build:
-	docker build . -t projects.registry.vmware.com/cbcontainers/harbor_adapter:$(release_version)
+	docker build . -t cbartifactory/harbor_adapter:$(release_version)
 
 publish: check-release-var docker-build
-	docker push projects.registry.vmware.com/cbcontainers/harbor_adapter:$(release_version)
+	docker push cbartifactory/harbor_adapter:$(release_version)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,7 @@ All configuration values for the Harbor Adapter can be set using the following e
 The easiest was to deploy Harbor Adapter is through the `helm install` command and make sure you provide all the necessary arguments as mentioned below:
 
 ```
-$ helm repo add cb-harbor-adapter https://projects.registry.vmware.com/chartrepo/cb_harbor_adapter
-"cb-harbor-adapter" has been added to your repositories
-
-$ helm install carbon-black --set cb_image_scanning.api_id=,<YOUR_API_ID_HERE>,cb_image_scanning.org_key=<YOUR_ORG_KEY_HERE>,cb_image_scanning.api_key=<YOUR_API_KEY_HERE>,cb_image_scanning.url=<YOUR_URL_HERE>  cb-harbor-adapter/harbor-adapter
+$ helm install carbon-black --set cb_image_scanning.api_id=,<YOUR_API_ID_HERE>,cb_image_scanning.org_key=<YOUR_ORG_KEY_HERE>,cb_image_scanning.api_key=<YOUR_API_KEY_HERE>,cb_image_scanning.url=<YOUR_URL_HERE> oci://registry-1.docker.io/cbartifactory/cb-harbor-adapter
 NAME: carbon-black
 LAST DEPLOYED: Thu Apr 15 02:40:37 2021
 NAMESPACE: default
@@ -69,13 +66,12 @@ You can also provide the configuration through values file and make sure you pro
 * cb_image_scanning.url
 
 ```
-$ helm repo add cb-harbor-adapter https://projects.registry.vmware.com/chartrepo/cb_harbor_adapter
-"cb-harbor-adapter" has been added to your repositories
-
-$ helm install carbon-black -f values.yaml cb-harbor-adapter/harbor-adapter
+$ helm install carbon-black -f values.yaml oci://registry-1.docker.io/cbartifactory/cb-harbor-adapter
 ```
 
 Here is the sample [values.yaml](helm/values.yaml) file
+
+NOTE: The old repository at [projects.registry.vmware.com](https://projects.registry.vmware.com/chartrepo/cb_harbor_adapter) is now deprecated and will not be updated with new releases. Thus, you may need to run `helm uninstall` and then `helm install` to get the latest release, if you are using the old repository.
 
 ### kubectl apply
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This allows a local development loop of "make change -> `docker build` -> start 
 ## Creating a release
 
 These steps should be followed when publishing a new release of the adapter:
-1. Run `make publish release_version=X` where X is the new version to release (e.g. 3.0). This requires access to the project's Harbor registry.
+1. Run `make publish release_version=X` where X is the new version to release (e.g. 3.0). This requires access to the project's Docker Hub account.
 2. Bump the chart and/or app version in [Chart.yaml](./helm/Chart.yaml)
 3. Change the default image tag under [Helm](./helm/values.yaml) and [K8S](./k8s/cb-harbor-adapter.yaml) to match the new version.
 4. Open an MR

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: harbor-adapter
+name: cb-harbor-adapter
 description: An adapter between Harbor registry and CarbonBlack image scanning.
-version: 0.2.0
-appVersion: 0.2.0
+version: 2.2.0
+appVersion: 2.2.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ fullnameOverride:
 replicaCount: 1
 
 image:
-  image: cbartifactory/harbor_adapter:2.1
+  image: cbartifactory/harbor_adapter:2.2
   imagePullPolicy: IfNotPresent
 
 cb_image_scanning:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ fullnameOverride:
 replicaCount: 1
 
 image:
-  image: projects.registry.vmware.com/cbcontainers/harbor_adapter:2.1
+  image: cbartifactory/harbor_adapter:2.1
   imagePullPolicy: IfNotPresent
 
 cb_image_scanning:

--- a/k8s/cb-harbor-adapter.yaml
+++ b/k8s/cb-harbor-adapter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: cb-harbor-adapter
-        image: projects.registry.vmware.com/cbcontainers/harbor_adapter:2.1
+        image: cbartifactory/harbor_adapter:2.1
         env:
         - name: CB_API_ID
           valueFrom:

--- a/k8s/cb-harbor-adapter.yaml
+++ b/k8s/cb-harbor-adapter.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: cb-harbor-adapter
-        image: cbartifactory/harbor_adapter:2.1
+        image: cbartifactory/harbor_adapter:2.2
         env:
         - name: CB_API_ID
           valueFrom:


### PR DESCRIPTION
Release version 2.2.

This also includes:
- Redirect all OCI image and Helm references to Docker Hub
- Update the README.md file
- Make sure the release is built with Golang 1.22